### PR TITLE
Docker - make section clear

### DIFF
--- a/tools/docker.md
+++ b/tools/docker.md
@@ -1,33 +1,4 @@
 Docker
 ======
 
-
-
-## Build an image
-
-Docker builds and image from a file called `Dockerfile`
-
-    docker build -t <somename> <path to Dockerfile>
-
-For example (where a file called 'Dockerfile' is in the current working directory)
-
-    docker build -t lodspeaker .
-
-## Run an image to create a contianer
-
-You then run an image to create a container
-
-    docker run --publish=127.0.0.2:80:80 lodspeakr
-
-## Inspect a container
-You can inspect that container..
-
-### List processes
-
-    sudo docker ps
-
-and you can 
-
-#### Inspect processes
-
-    sudo docker inspect <some identifier, e.g. Name, ID, etc>
+We don't currently use Docker in dev or production.


### PR DESCRIPTION
Updated Docker page to make clear what I think is current reality - ie, we don't use it.

Also, I'm a bit unsure about putting handy commands into these docs. If we do that to much, I think they could just end up as a tutorial, and there must be lots out there we can just link to. I think putting handy commands in is problematic as some readers will be at different levels and thus won't need them, and for them they just become noise that get in the way of finding useful info in the docs. Also, handy commands make assumptions (eg from these ones: you want to publish port 80 on IP 127.0.0.2) which might not be true for all users or might need further explanation. (I want to think about this a bit more tho, but I think this P.R. is still good.)