### PR TITLE
Start database page with table names

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
     * [Notes about Open Data Services Python Code](code-python.md)
         * [Debugging Python Code](debugging-python-code.md)
     * [Front End Development](front-end-development.md)
+    * [Database](database.md)
     * [Security considerations](security.md)
     * [Deployment](deployment.md)
         * [Page Load Speed](page-load-speed.md)

--- a/database.md
+++ b/database.md
@@ -4,3 +4,5 @@
 
 Table names are singular. (eg "record" not "records")
 
+(This is Django's default behaviour around model names.)
+

--- a/database.md
+++ b/database.md
@@ -1,0 +1,6 @@
+# Database
+
+## Schema Design
+
+Table names are singular. (eg "record" not "records")
+


### PR DESCRIPTION
Well ....

I have no strong reasons to argue that they should be singular - it's just always seemed clearer. You tend to deal with rows one at a time, and so the name should reflect what one row of a table is. For instance, if you have a table of cars each row is one car, so the table should be called "car". If dealing with a system where models mirror table names, you want the model to be "Car" to. 

But I accept that is really getting down to a preference. If you all tell me plural, so be it :-)